### PR TITLE
fix: js api should never call process.exit on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "build:es": "tsc -m esNext --outDir esm --declaration false",
     "build": "npm run build:cjs && npm run build:es",
     "lint": "eslint . --ext .js,.ts",
-    "prettier": "prettier --check ."
+    "prettier": "prettier --check .",
+    "format": "prettier --write src/*"
   },
   "keywords": [],
   "author": "",
@@ -52,6 +53,6 @@
   },
   "lint-staged": {
     "*.{js,ts}": "eslint --cache --fix",
-    "*.{js,css,md}": "prettier --write"
+    "*.{js,css,md,ts}": "prettier --write"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,30 +31,32 @@ program
       mainBranch,
       repo,
       since,
-    }).then((isAffectedResult) => {
-      if (!isAffectedResult) {
-        console.log(
-          chalk.yellow(
-            `${glob} is not present in diff. Skipping command: ${cmd}`
-          )
-        );
-        return;
-      }
+    })
+      .then((isAffectedResult) => {
+        if (!isAffectedResult) {
+          console.log(
+            chalk.yellow(
+              `${glob} is not present in diff. Skipping command: ${cmd}`
+            )
+          );
+          return;
+        }
 
-      console.log(
-        chalk.green(`${glob} is present in diff. Running command: ${cmd}`)
-      );
-      return exec(cmd, cwd).catch(() => {
-        console.error(
-          chalk.bgRed(
-            `${os.EOL}ERROR: can't exec your command.${os.EOL}command: ${cmd}`
-          )
+        console.log(
+          chalk.green(`${glob} is present in diff. Running command: ${cmd}`)
         );
+        return exec(cmd, cwd).catch(() => {
+          console.error(
+            chalk.bgRed(
+              `${os.EOL}ERROR: can't exec your command.${os.EOL}command: ${cmd}`
+            )
+          );
+          process.exit(1);
+        });
+      })
+      .catch((error) => {
+        console.error(chalk.bgRed(error.message));
         process.exit(1);
       });
-    }).catch((error) => {
-      console.error(chalk.bgRed(error.message));
-      process.exit(1);
-    });
   })
   .parse(process.argv);

--- a/src/is-affected.ts
+++ b/src/is-affected.ts
@@ -23,11 +23,7 @@ export const isAffected = async (
 
   const getCommitToDiffWith = async () => {
     const masterCommit = await repo.getBranchCommit(mainBranch);
-    const toSha = await nodegit.Merge.base(
-      repo,
-      from.id(),
-      masterCommit.id()
-    );
+    const toSha = await nodegit.Merge.base(repo, from.id(), masterCommit.id());
 
     return repo.getCommit(toSha);
   };


### PR DESCRIPTION
BREAKING CHANGE: you must now handle exceptions from js isAffected()
yourself. isAffected() will no longer call process.exit(1) when any
error is thrown.